### PR TITLE
Feat/daily-virage start sound

### DIFF
--- a/src/app-images-randomizer/stores/images-randomizer.js
+++ b/src/app-images-randomizer/stores/images-randomizer.js
@@ -9,6 +9,7 @@ const store = {
     selectedText: null,
     images: null,
     fixedTime: null,
+    sounds: null,
   },
   mutations: {
     updateRandomizer: (state, payload) => {
@@ -18,6 +19,7 @@ const store = {
       state.selectedText = payload.selectedText || null;
       state.images = payload.images || null;
       state.fixedTime = payload.fixedTime || null;
+      state.sounds = payload.sounds || null;
     },
   },
   actions: {

--- a/src/app-images-randomizer/views/AppImagesRandomizer.vue
+++ b/src/app-images-randomizer/views/AppImagesRandomizer.vue
@@ -25,6 +25,9 @@ import store from '@/services/store';
 export default {
   name: 'app-images-randomizer',
   store,
+  props: {
+    config: Object,
+  },
   destroyed() {
     this.clearAnim();
     this.clearRandomizeImages();
@@ -79,6 +82,16 @@ export default {
       this.clearAnim();
       this.clearRandomizeImages();
       this.clearEnd();
+
+      if (this.sounds && this.sounds.start) {
+        const audio = new Audio(this.sounds.start);
+        audio.loop = false;
+        // eslint-disable-next-line no-console
+        audio.play().catch(() => console.warn(
+          `Impossible to play "${this.sounds.start}"`,
+          `(maybe the user didn't interact with the page)`
+        ));
+      }
 
       this.anim('appearSb', [0, 350, 350], 0, () => setTimeout(this.startRandomizeImages, 350));
     },

--- a/src/app-images-randomizer/views/AppImagesRandomizer.vue
+++ b/src/app-images-randomizer/views/AppImagesRandomizer.vue
@@ -31,7 +31,7 @@ export default {
   },
   computed: {
     ...mapState('ImagesRandomizer', [
-      'id', 'icon', 'title', 'selectedText', 'images', 'fixedTime'
+      'id', 'icon', 'title', 'selectedText', 'images', 'fixedTime', 'sounds',
     ]),
   },
   data() {


### PR DESCRIPTION
# SPEC

Add the same feature as the Google Calendar or Github pulls apps, by adding a "sounds" attribute in the app config.

# How To Test

1. In your palantir.json, in daily-virage config, add a "sounds" item with one sound called "start" linking to a mp3 sound located in the "sounds" folder.
![image](https://user-images.githubusercontent.com/32329416/58800101-4e6a6780-8607-11e9-8ffc-9cf1fa0b537d.png)
**Download sound :** [mario.mp3.zip](https://github.com/CodeCorico/palantir/files/3247729/mario.mp3.zip)
2. `npm run build` 
3. `npm run start`
4. go on your local palantir `http://localhost:3000/` and launch the app daily virage

