### PR TITLE
Fix/app images randomizer

### DIFF
--- a/src/app-images-randomizer/views/AppImagesRandomizer.vue
+++ b/src/app-images-randomizer/views/AppImagesRandomizer.vue
@@ -95,7 +95,7 @@ export default {
     startRandomizeImages() {
       const minLoops = this.images.length * 4;
       const maxLoops = this.images.length * 5;
-      const loops = Math.floor(Math.random() * (maxLoops - minLoops + 1) + minLoops) - 1;
+      const loops = Math.floor(Math.random() * (maxLoops - minLoops) + minLoops);
 
       this.randomizeImages(0, loops);
     },


### PR DESCRIPTION
Randomness is falsed because it applies incorrect boundaries on Math.random. 

Previously, we computed a random number between `this.users.length * 5` and `this.users.length * 6 - 1` and choose a user by doing this random number modulo `this.users.length` to get the user by its index.

So we skipped the last user in our calculus, and if we increase the loop gap by `x`, the last user would be counted `x` time less than others. Thus, by a gap of 1, the last user was never considered.

You could verify it here: 
Incorrect: https://jsfiddle.net/1p4t7b2a/1/
Correct: https://jsfiddle.net/c612sn4j/